### PR TITLE
Disable hardware acceleration of CompatSaturationValuePanel

### DIFF
--- a/hsvpicker/compose/src/main/kotlin/io/github/naverz/pinocchio/hsvpicker/compose/panel/SaturationValuePanel.kt
+++ b/hsvpicker/compose/src/main/kotlin/io/github/naverz/pinocchio/hsvpicker/compose/panel/SaturationValuePanel.kt
@@ -15,6 +15,7 @@ import android.graphics.Paint
 import android.graphics.PorterDuff
 import android.graphics.RectF
 import android.graphics.Shader
+import android.os.Build
 import android.view.View
 import androidx.annotation.FloatRange
 import androidx.compose.foundation.background
@@ -298,6 +299,13 @@ private class CompatSaturationValuePanel(context: Context, rtl: Boolean) :
 
     private var panelPaint = Paint().apply {
         isAntiAlias = true
+    }
+
+    init {
+        // Ref : https://developer.android.com/topic/performance/hardware-accel?hl=en#drawing-support
+        if (Build.VERSION.SDK_INT <= 27) {
+            setLayerType(LAYER_TYPE_SOFTWARE, null)
+        }
     }
 
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {


### PR DESCRIPTION
## 원인
1. CompatSaturationValuePanel 내부에서 ComposeShader 가 사용됨. 
2. 안드로이드는 API 11 부터 뷰를 렌더링할 때 기본적으로 하드웨어 가속이 활성화 됨. 성능상으로 이점이 크나, API 에 따라 지원되는 동작이 다름.
3. CompatSaturationValuePanel 의 경우 ComposeShader 에 동일한 타입의 셰이더를 지정한 케이스인데, 이는 API 28 부터 지원 됨. 따라서 28 미만 API 디바이스에서는 의도하지 않은 동작이 발생함.
- Ref : https://developer.android.com/topic/performance/hardware-accel?hl=en#drawing-support
<img width="894" alt="Screen Shot 2023-01-26 at 3 14 30 PM" src="https://user-images.githubusercontent.com/27072782/214771919-506fe4b4-fa82-4552-98e3-045b2992664b.png">
 

## 해결
- CompatSaturationValuePanel 에 한해서 하드웨어 가속을 비활성화하고 Software-base drawing model 로 변경